### PR TITLE
Iptables rule

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -12,6 +12,9 @@ smtp_password:
 
 # disable when using LXC
 selinux: true
+selinux_state: enforcing
+selinux_policy: targeted
+
 
 # server alias used in httpd
 httpd_alias:

--- a/group_vars/retrace_server
+++ b/group_vars/retrace_server
@@ -1,0 +1,7 @@
+---
+#Variables for retrace server
+
+#permissive selinux
+selinux_state: permissive
+selinux_policy: targeted
+selinux: true

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -34,7 +34,7 @@
   service: name=ntpd state=started enabled=yes
 
 - name: SELinux Enforcing (Targeted)
-  selinux: policy=targeted state=enforcing
+  selinux: policy="{{selinux_policy}}" state="{{selinux_state}}"
   when: selinux
   tags:
   - selinux

--- a/roles/common/templates/iptables-v4.j2
+++ b/roles/common/templates/iptables-v4.j2
@@ -5,3 +5,4 @@
 {% endif %}
 {% endfor %}
 {% endif %}
+-A INPUT -p tcp --dport 443 -j ACCEPT


### PR DESCRIPTION
Creating new iptables rule for retrace-server because retrace-server need to have opened port 443 for correct installation