### PR TITLE
firewall: Use python3 subpackage for firewalld

### DIFF
--- a/roles/common/tasks/firewall.yml
+++ b/roles/common/tasks/firewall.yml
@@ -10,8 +10,12 @@
 # skip block if firewalld is missing
 - block:
   - name: install python-firewall for fedora
-    package: name=python-firewall state=present
-    when: ansible_distribution == 'Fedora'
+    package: name=python-firewall state=latest
+    when: ansible_distribution == 'Fedora' and ansible_distribution_version|int <= 27
+
+  - name: install python3-firewall for fedora 28+
+    package: name=python3-firewall state=latest
+    when: ansible_distribution == 'Fedora' and ansible_distribution_version|int > 27
 
   - name: start and enable firewalld
     service: name=firewalld state=started enabled=yes


### PR DESCRIPTION
The python2-firewall subpackage was removed from F28 and only the
python3 version is available. (firewalld-0.5.2-2.fc28)

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>