### PR TITLE
Fix jinja test used as a filter

### DIFF
--- a/roles/common/tasks/firewall.yml
+++ b/roles/common/tasks/firewall.yml
@@ -24,4 +24,4 @@
     firewalld: service=https permanent=yes state=enabled
     notify: restart firewalld
 
-  when: fw_check|succeeded
+  when: fw_check is succeeded


### PR DESCRIPTION
Using tests as filters is deprecated.
Instead of using `result|succeeded` instead use `result is succeeded`.
This feature will be removed in version 2.9.

https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>